### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ BASE-9 may be the code for you if
 Installation
 ------------
 
-We designed BASE-9 to run under a variety of UNIX and Linux operating systems, though we have not tested it under a wide variety of systems. Currently we have BASE-9 running under Mac OS 10.6 and 10.8 and Linux Ubuntu 10.04. The code is written primarily in the C++ programming language. BASE-9 also takes advantage of parallel computing for the numerical integrations using a hybrid scheme utilizing MPI and C++11 threads. You will need g++ (a C++ compiler associated with GCC) version 4.8 or newer or clang++ version 3.2 or newer (available with XCode 4.6), GSL (the Gnu Science Library), cmake (a cross-platform build system) version 2.8.10 or newer, Boost (a peer-reviewed C++ library) 1.54 or newer, and Open MPI (a high performance message passing library) to compile the code. To install these software packages, you may need help from your system administrator, though we provide some guidance in [the manual] (https://base-9.readthedocs.io/).
+We designed BASE-9 to run under a variety of UNIX and Linux operating systems, though we have not tested it under a wide variety of systems. Currently we have BASE-9 running under Mac OS 10.6, 10.8, and 10.12.4 and Linux Ubuntu 10.04. The code is written primarily in the C++ programming language. BASE-9 also takes advantage of parallel computing for the numerical integrations using a hybrid scheme utilizing MPI and C++11 threads. You will need g++ (a C++ compiler associated with GCC) version 4.8 or newer or clang++ version 3.2 or newer (available with XCode 4.6), GSL (the Gnu Science Library), cmake (a cross-platform build system) version 2.8.10 or newer, Boost (a peer-reviewed C++ library) 1.54 or newer, and Open MPI (a high performance message passing library) to compile the code. To install these software packages, you may need help from your system administrator, though we provide some guidance in [the manual](http://webfac.db.erau.edu/~vonhippt/base9/Manual_files/BASE-9_Manual.pdf).  An up-to-date version of the manual is kept on ReadTheDocs [here](http://base-9.readthedocs.io/en/latest/).
 
 C++11
 -----
@@ -32,7 +32,8 @@ As of version 9.3.0, BASE-9 is dependent upon a C++11 compliant compiler for pro
 
 References
 ----------
-* [Embry-Riddle Aeronautical University] (http://www.erau.edu)
-* [The BASE homepage] (http://webfac.db.erau.edu/~vonhippt/base9/)
+* [Embry-Riddle Aeronautical University](http://www.erau.edu)
+* [The BASE homepage](http://webfac.db.erau.edu/~vonhippt/base9/)
+* [The ReadTheDocs online manual](http://base-9.readthedocs.io/en/latest/)
 
 


### PR DESCRIPTION
This PR should fix the README to be compliant with the new (and inferior) markdown engine used by GitHub, per [issue 66](https://github.com/argiopetech/base/issues/66)